### PR TITLE
Lagt til mulighet for å vise feilet og manuell oppfølgning på førsteside

### DIFF
--- a/dev-server/mock-routes.js
+++ b/dev-server/mock-routes.js
@@ -45,4 +45,8 @@ app.get('/services', (req, res) => {
     });
 });
 
+app.get('/statistikk', (req, res) => {
+    setTimeout(() => res.send(lesMockFil(`tasks-statistikk.json`)), delayMs);
+});
+
 module.exports = app;

--- a/dev-server/mock/tasks-statistikk.json
+++ b/dev-server/mock/tasks-statistikk.json
@@ -1,0 +1,14 @@
+{
+  "status": "SUKSESS",
+  "melding": "Innhenting av data var vellykket",
+  "errorMelding": null,
+  "data": {
+    "hentet": 1626017451240,
+    "statistikk": {
+      "familie-ks-mottak": {
+        "FERDIG": 1,
+        "FEILET": 3
+      }
+    }
+  }
+}

--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { buildPath } from './config';
 import { IService, serviceConfig } from './serviceConfig';
 import WebpackDevMiddleware from 'webpack-dev-middleware';
+import { hentStatistikk } from './statistikk';
 
 export default (
     authClient: Client,
@@ -29,6 +30,14 @@ export default (
             })
             .end();
     });
+
+    router.get(
+        '/statistikk',
+        ensureAuthenticated(authClient, false),
+        (req: Request, res: Response) => {
+            hentStatistikk(req, res);
+        }
+    );
 
     // APP
     if (process.env.NODE_ENV === 'development') {

--- a/src/backend/serviceConfig.ts
+++ b/src/backend/serviceConfig.ts
@@ -4,6 +4,7 @@ export interface IService {
     proxyPath: string;
     id: string;
     proxyUrl: string;
+    statistikk?: boolean;
 }
 
 let proxyUrls: { [key: string]: string } = {};
@@ -54,13 +55,7 @@ export const serviceConfig: IService[] = [
         id: 'familie-ef-mottak',
         proxyPath: '/familie-ef-mottak/api',
         proxyUrl: proxyUrls.enslig_mottak,
-    },
-    {
-        clientId: process.env.FAMILIE_TILBAKE_CLIENT_ID,
-        displayName: 'Tilbakekreving',
-        id: 'familie-tilbake',
-        proxyPath: '/familie-tilbake/api',
-        proxyUrl: proxyUrls.tilbake,
+        statistikk: false,
     },
     {
         clientId: process.env.EF_SAK_CLIENT_ID,
@@ -75,5 +70,12 @@ export const serviceConfig: IService[] = [
         id: 'familie-ef-iverksett',
         proxyPath: '/familie-ef-iverksett/api',
         proxyUrl: proxyUrls.enslig_iverksett,
+    },
+    {
+        clientId: process.env.FAMILIE_TILBAKE_CLIENT_ID,
+        displayName: 'Tilbakekreving',
+        id: 'familie-tilbake',
+        proxyPath: '/familie-tilbake/api',
+        proxyUrl: proxyUrls.tilbake,
     },
 ];

--- a/src/backend/statistikk.ts
+++ b/src/backend/statistikk.ts
@@ -1,0 +1,101 @@
+import { Request, Response } from 'express';
+import { IService, serviceConfig } from './serviceConfig';
+import request, { Response as RequestResponse } from 'request';
+
+const buildError = (service: IService, response: RequestResponse, error: any) => {
+    return {
+        id: service.id,
+        statusCode: response.statusCode,
+        error,
+    };
+};
+
+interface Statistikk {
+    id: string;
+    statistikk: {
+        [key: string]: number;
+    };
+}
+
+interface Cache {
+    status: 'IKKE_HENTET' | 'HENTER' | 'HENTET';
+    age: number;
+    data: unknown;
+}
+
+const statistikkCache: Cache = {
+    status: 'IKKE_HENTET',
+    age: Date.now(),
+    data: {},
+};
+
+const hent = (req: Request, res: Response) => {
+    const requests = serviceConfig
+        .filter((service: IService) => service.statistikk)
+        .map((service: IService) => {
+            const url = `${service.proxyUrl}/api/task/statistikk`;
+            return new Promise((resolve, reject) => {
+                request.get(url, (error, response: RequestResponse, body) => {
+                    if (error) {
+                        reject(buildError(service, response, error));
+                    } else {
+                        try {
+                            resolve({
+                                id: service.id,
+                                statistikk: JSON.parse(body),
+                            });
+                        } catch (e) {
+                            reject(buildError(service, response, body));
+                        }
+                    }
+                });
+            });
+        });
+    Promise.all(requests)
+        .then((values: Statistikk[]) => {
+            const response = {
+                data: {
+                    hentet: Date.now(),
+                    historikk: values.reduce((acc, r: Statistikk) => {
+                        acc[r.id] = r.statistikk;
+                        return acc;
+                    }, {} as any),
+                },
+                status: 'SUKSESS',
+            };
+            statistikkCache.age = Date.now();
+            statistikkCache.data = response;
+            statistikkCache.status = 'HENTET';
+            res.status(200).send(response).end();
+        })
+        .catch((error) => {
+            statistikkCache.status = 'IKKE_HENTET';
+            res.status(200)
+                .send({
+                    status: 'FEILET',
+                    frontendFeilmelding: error,
+                })
+                .end();
+        });
+};
+
+export const hentStatistikk = (req: Request, res: Response) => {
+    const now = Date.now();
+    let age = now - statistikkCache.age;
+    if (statistikkCache.status === 'IKKE_HENTET' || age > 2 * 60_000) {
+        statistikkCache.status = 'HENTER';
+        statistikkCache.age = Date.now();
+        hent(req, res);
+    } else if (statistikkCache.status === 'HENTER') {
+        if (age > 5_000) {
+            statistikkCache.age = Date.now();
+            hent(req, res);
+        } else {
+            setTimeout(() => {
+                hentStatistikk(req, res);
+            }, 5_000 - age);
+        }
+    } else {
+        res.status(200).send(statistikkCache.data).end();
+    }
+};

--- a/src/frontend/api/service.ts
+++ b/src/frontend/api/service.ts
@@ -1,10 +1,17 @@
 import { Ressurs } from '../typer/ressurs';
-import { IService } from '../typer/service';
+import { IService, IServiceStatistikkResponse } from '../typer/service';
 import { axiosRequest } from './axios';
 
 export const hentServices = (): Promise<Ressurs<IService[]>> => {
     return axiosRequest({
         method: 'GET',
         url: `/services`,
+    });
+};
+
+export const hentServiceStatistikk = (): Promise<Ressurs<IServiceStatistikkResponse>> => {
+    return axiosRequest({
+        method: 'GET',
+        url: `/statistikk`,
     });
 };

--- a/src/frontend/komponenter/Services/Services.tsx
+++ b/src/frontend/komponenter/Services/Services.tsx
@@ -1,12 +1,13 @@
 import AlertStripe from 'nav-frontend-alertstriper';
-import { Systemtittel } from 'nav-frontend-typografi';
+import { Normaltekst, Systemtittel } from 'nav-frontend-typografi';
 import * as React from 'react';
 import { useHistory } from 'react-router';
-import { IService } from '../../typer/service';
+import { IService, IServiceStatistikkResponse, IStatusAntall } from '../../typer/service';
 import { actions, Dispatch, useServiceContext, useServiceDispatch } from '../ServiceProvider';
 import ServiceIkon from './ServiceIkon';
 import { Knapp } from 'nav-frontend-knapper';
 import { RessursStatus } from '@navikt/familie-typer';
+import 'nav-frontend-tabell-style';
 
 const Services: React.FunctionComponent = () => {
     const services = useServiceContext().services;
@@ -16,9 +17,14 @@ const Services: React.FunctionComponent = () => {
     switch (services.status) {
         case RessursStatus.SUKSESS:
             return (
-                <div className={'services'}>
-                    {services.data.map((service: IService) => Service(service, dispatch, history))}
-                </div>
+                <>
+                    <div className={'services'}>
+                        {services.data.map((service: IService) =>
+                            Service(service, dispatch, history)
+                        )}
+                    </div>
+                    {serviceTabell(services.data, dispatch, history)}
+                </>
             );
         case RessursStatus.HENTER:
             return <AlertStripe children={`Laster tasker`} type={'info'} />;
@@ -34,10 +40,70 @@ const Services: React.FunctionComponent = () => {
     }
 };
 
+const serviceTabell = (services: IService[], dispatch: Dispatch, history: any) => {
+    const serviceStatistikk = useServiceContext().serviceStatistikk;
+    const { statistikk, hentet }: IServiceStatistikkResponse =
+        serviceStatistikk.status === RessursStatus.SUKSESS
+            ? serviceStatistikk.data
+            : { statistikk: {} };
+    return (
+        <>
+            {hentet && (
+                <Normaltekst>Statistikk hentet: {new Date(hentet).toLocaleString()}</Normaltekst>
+            )}
+            <table className="tabell tabell--stripet">
+                <thead>
+                    <tr>
+                        <th>Navn</th>
+                        <th>Tasks</th>
+                        <th>Feilet</th>
+                        <th>Manuell oppfølgning</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {services.map((service: IService) => (
+                        <tr key={service.id}>
+                            <td>{service.displayName}</td>
+                            <td>
+                                <Knapp
+                                    onClick={() => {
+                                        dispatch({
+                                            payload: service,
+                                            type: actions.SETT_VALGT_SERVICE,
+                                        });
+                                        history.push(`/service/${service.id}`);
+                                    }}
+                                    mini={true}
+                                >
+                                    Alle tasker
+                                </Knapp>
+                                <Knapp
+                                    onClick={() => {
+                                        dispatch({
+                                            payload: service,
+                                            type: actions.SETT_VALGT_SERVICE,
+                                        });
+                                        history.push(`/service/${service.id}/gruppert`);
+                                    }}
+                                    mini={true}
+                                >
+                                    Gruppert
+                                </Knapp>
+                            </td>
+                            <td>{statistikk[service.id]?.FEILET}</td>
+                            <td>{statistikk[service.id]?.MANUELL_OPPFØLGING}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </>
+    );
+};
+
 const Service = (service: IService, dispatch: Dispatch, history: any) => {
     return (
         <div key={service.id} className={'services__service'}>
-            <ServiceIkon heigth={150} width={150} />
+            <ServiceIkon heigth={100} width={100} />
             <Systemtittel children={service.displayName} />
 
             <div className={'services__service--actions'}>

--- a/src/frontend/typer/service.ts
+++ b/src/frontend/typer/service.ts
@@ -1,5 +1,18 @@
+import { taskStatus } from './task';
+
 export interface IService {
     displayName: string;
     id: string;
     proxyPath: string;
 }
+
+export interface IServiceStatistikkResponse {
+    hentet?: number;
+    statistikk: {
+        [key: string]: IStatusAntall;
+    };
+}
+
+export type IStatusAntall = {
+    [key in taskStatus]: number;
+};


### PR DESCRIPTION
For å enklere se hvor mange tasks som har feilet så ønsker jeg antall feilet på første siden

Dette er eksempel, og er åpen for diskusjon

![image](https://user-images.githubusercontent.com/937168/125201787-c983ba80-e270-11eb-8fbb-5c5ca9b32447.png)

