### PR TITLE
Lagt til støtte for task-filtrering basert på type

### DIFF
--- a/src/backend/serviceConfig.ts
+++ b/src/backend/serviceConfig.ts
@@ -15,6 +15,7 @@ if (process.env.ENV === 'local') {
         enslig_mottak: 'http://localhost:8092',
         enslig_sak: 'http://localhost:8093',
         kontantstøtte_mottak: 'http://localhost:8084',
+        barnetrygd_migrering: 'http://localhost:8098',
     };
 } else {
     proxyUrls = {

--- a/src/frontend/api/task.ts
+++ b/src/frontend/api/task.ts
@@ -6,15 +6,17 @@ import { Ressurs } from '@navikt/familie-typer';
 export const hentTasks = (
     valgtService: IService,
     statusFilter: taskStatus,
-    side: number
+    side: number,
+    type: string
 ): Promise<Ressurs<ITaskResponse>> => {
-    const params =
+    const params: any =
         statusFilter !== taskStatus.ALLE
             ? {
                   status: statusFilter,
                   page: side,
               }
             : { page: side };
+    if (type !== '') params.type = type;
     return axiosRequest({
         params,
         method: 'GET',

--- a/src/frontend/komponenter/Task/TaskListe.tsx
+++ b/src/frontend/komponenter/Task/TaskListe.tsx
@@ -11,7 +11,7 @@ interface IProps {
 }
 
 const TaskListe: React.FC<IProps> = ({ tasks }) => {
-    const { statusFilter } = useTaskContext();
+    const { statusFilter, type } = useTaskContext();
 
     return tasks.length > 0 ? (
         <React.Fragment>
@@ -24,7 +24,10 @@ const TaskListe: React.FC<IProps> = ({ tasks }) => {
                 })}
         </React.Fragment>
     ) : (
-        <AlertStripe type={'info'} children={`Ingen tasker med status ${statusFilter}`} />
+        <AlertStripe
+            type={'info'}
+            children={`Ingen tasker med status ${statusFilter}${type ? ` av type ${type}` : ''}`}
+        />
     );
 };
 

--- a/src/frontend/komponenter/TaskProvider.tsx
+++ b/src/frontend/komponenter/TaskProvider.tsx
@@ -82,6 +82,7 @@ const [TaskProvider, useTaskContext] = constate(() => {
         settSide,
         statusFilter,
         settStatusFilter,
+        type,
         settTypeFilter,
         rekjørTasks,
         avvikshåndter,

--- a/src/frontend/komponenter/TaskProvider.tsx
+++ b/src/frontend/komponenter/TaskProvider.tsx
@@ -17,6 +17,11 @@ const getQueryParamSide = (location: Location): number => {
     return queryParamSideAsString ? parseInt(queryParamSideAsString, 10) : 0;
 };
 
+const getQueryParamTaskType = (location: Location): string => {
+    const taskType = new URLSearchParams(location.search).get('taskType');
+    return taskType || '';
+};
+
 const [TaskProvider, useTaskContext] = constate(() => {
     const { valgtService } = useServiceContext();
     const navigate = useNavigate();
@@ -27,25 +32,29 @@ const [TaskProvider, useTaskContext] = constate(() => {
         getQueryParamStatusFilter(location)
     );
     const [side, settSide] = useState<number>(getQueryParamSide(location));
+    const [type, settTypeFilter] = useState<string>(getQueryParamTaskType(location));
 
     const hentEllerOppdaterTasks = () => {
         if (valgtService) {
-            hentTasks(valgtService, statusFilter, side).then((res) => settTasks(res));
+            hentTasks(valgtService, statusFilter, side, type).then((res) => settTasks(res));
         }
     };
 
     useEffect(() => {
         hentEllerOppdaterTasks();
-    }, [valgtService, statusFilter, side]);
+    }, [valgtService, statusFilter, side, type]);
 
     useEffect(() => {
         if (
             getQueryParamStatusFilter(location) !== statusFilter ||
-            getQueryParamSide(location) !== side
+            getQueryParamSide(location) !== side ||
+            getQueryParamTaskType(location) !== type
         ) {
-            navigate(`${location.pathname}?statusFilter=${statusFilter}&side=${side}`);
+            navigate(
+                `${location.pathname}?statusFilter=${statusFilter}&side=${side}&taskType=${type}`
+            );
         }
-    }, [statusFilter, side, history]);
+    }, [statusFilter, side, type, history]);
 
     const rekjørTasks = (id?: number) => {
         if (valgtService && statusFilter) {
@@ -73,6 +82,7 @@ const [TaskProvider, useTaskContext] = constate(() => {
         settSide,
         statusFilter,
         settStatusFilter,
+        settTypeFilter,
         rekjørTasks,
         avvikshåndter,
     };


### PR DESCRIPTION
Hører sammen med branch feature/filtrering_på_type i familie-prosessering-backend
Testet Lokalt:
![image](https://user-images.githubusercontent.com/47184872/161020396-1929d370-4917-4fd7-9d46-7593066fc786.png)
