### PR TITLE
Tea-9765: Legg til baks mottak

### DIFF
--- a/build_n_deploy/naiserator/gcp-dev.yaml
+++ b/build_n_deploy/naiserator/gcp-dev.yaml
@@ -38,6 +38,7 @@ spec:
         - application: familie-ba-migrering
         - application: familie-ba-sak
         - application: familie-ks-sak
+        - application: familie-baks-mottak
       external:
         - host: familie-ba-mottak.dev-fss-pub.nais.io
         - host: familie-ks-mottak.dev-fss-pub.nais.io

--- a/build_n_deploy/naiserator/gcp-prod.yaml
+++ b/build_n_deploy/naiserator/gcp-prod.yaml
@@ -37,6 +37,7 @@ spec:
         - application: familie-ba-migrering
         - application: familie-ba-sak
         - application: familie-ks-sak
+        - application: familie-baks-mottak
       external:
         - host: familie-ba-mottak.prod-fss-pub.nais.io
         - host: familie-ks-mottak.prod-fss-pub.nais.io

--- a/src/backend/serviceConfig.ts
+++ b/src/backend/serviceConfig.ts
@@ -20,6 +20,7 @@ if (process.env.ENV === 'local') {
         kontantstøtte_mottak: 'http://localhost:8084',
         kontantstøtte_sak: 'http://localhost:8083',
         barnetrygd_migrering: 'http://localhost:8098',
+        baks_mottak: 'http://localhost:8084',
     };
 } else {
     proxyUrls = {
@@ -33,6 +34,7 @@ if (process.env.ENV === 'local') {
         tilbake: `http://familie-tilbake`,
         klage: `http://familie-klage`,
         barnetrygd_migrering: `http://familie-ba-migrering`,
+        baks_mottak: `http://familie-baks-mottak`,
     };
 }
 
@@ -113,6 +115,13 @@ export const serviceConfig: IService[] = [
         displayName: 'Alene med barn - iverksett',
         id: 'familie-ef-iverksett',
         proxyPath: '/familie-ef-iverksett/api',
+        proxyUrl: proxyUrls.enslig_iverksett,
+    },
+    {
+        cluster: 'gcp',
+        displayName: 'BAKS mottak',
+        id: 'familie-baks-mottak',
+        proxyPath: '/familie-baks-mottak/api',
         proxyUrl: proxyUrls.enslig_iverksett,
     },
 ];

--- a/src/backend/serviceConfig.ts
+++ b/src/backend/serviceConfig.ts
@@ -20,7 +20,7 @@ if (process.env.ENV === 'local') {
         kontantstøtte_mottak: 'http://localhost:8084',
         kontantstøtte_sak: 'http://localhost:8083',
         barnetrygd_migrering: 'http://localhost:8098',
-        baks_mottak: 'http://localhost:8084',
+        baks_mottak: 'http://localhost:8090',
     };
 } else {
     proxyUrls = {

--- a/src/backend/serviceConfig.ts
+++ b/src/backend/serviceConfig.ts
@@ -122,6 +122,6 @@ export const serviceConfig: IService[] = [
         displayName: 'BAKS mottak',
         id: 'familie-baks-mottak',
         proxyPath: '/familie-baks-mottak/api',
-        proxyUrl: proxyUrls.enslig_iverksett,
+        proxyUrl: proxyUrls.baks_mottak,
     },
 ];


### PR DESCRIPTION
Jeg har
- Lagt til familie-baks-mottak til i familie-prosessering med navnet 'BAKS mottak'. Navnet er opp for diskusjon 😊 
- Lagt inn baks-mottak scope og clientId i **familie** secrets i preprod-gcp. Denne legges til i prod-gcp når baks mottak deployes der.