### PR TITLE
Oppdaterer til distroless image

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: yarn
           registry-url: "https://npm.pkg.github.com"
       - name: Yarn install

--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: yarn
           registry-url: "https://npm.pkg.github.com"
       - name: Yarn install

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: yarn
           registry-url: "https://npm.pkg.github.com"
       - name: Yarn install

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM cgr.dev/chainguard/node:18
 
 WORKDIR /app/server
 
-ADD ./ /var/server/
+ADD assets ./assets
+ADD node_dist ./node_dist
+ADD node_modules ./node_modules
+ADD package.json .
+
 
 EXPOSE 8000
 CMD ["/usr/bin/npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM cgr.dev/chainguard/node:18
 WORKDIR /app/server
 
 ADD assets ./assets
+ADD build_n_deploy ./build_n_deploy
 ADD node_dist ./node_dist
 ADD node_modules ./node_modules
 ADD package.json .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app/server
 ADD assets ./assets
 ADD build_n_deploy ./build_n_deploy
 ADD node_dist ./node_dist
+ADD frontend_production ./frontend_production
 ADD node_modules ./node_modules
 ADD package.json .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM navikt/node-express:14-alpine
+FROM cgr.dev/chainguard/node:18
+
+WORKDIR /app/server
 
 ADD ./ /var/server/
 
 EXPOSE 8000
-CMD ["yarn", "start"]
+CMD ["/usr/bin/npm", "run", "start"]


### PR DESCRIPTION
navikt/ sin blir ikke vedlikeholdt, og det anbefales å bruke distroless som ikke har like mange sikkerhetshull

https://nav-it.slack.com/archives/C60FFACN5/p1687344001574929
https://nav-it.slack.com/archives/C71GRG335/p1687519626532689?thread_ts=1687518423.343899&cid=C71GRG335