### PR TITLE
Fjerner CPU-limit

### DIFF
--- a/build_n_deploy/naiserator/gcp-dev-dagpenger.yaml
+++ b/build_n_deploy/naiserator/gcp-dev-dagpenger.yaml
@@ -18,7 +18,6 @@ spec:
   replicas:
     min: 1
     max: 1
-    cpuThresholdPercentage: 50
   ingresses:
     - "https://dp-prosessering.intern.dev.nav.no"
   azure:
@@ -35,7 +34,6 @@ spec:
         - application: tiltakspenger-iverksett
   resources:
     limits:
-      cpu: 2000m
       memory: 1024Mi
     requests:
       memory: 512Mi

--- a/build_n_deploy/naiserator/gcp-dev.yaml
+++ b/build_n_deploy/naiserator/gcp-dev.yaml
@@ -18,7 +18,6 @@ spec:
   replicas:
     min: 1
     max: 1
-    cpuThresholdPercentage: 50
   ingresses:
     - "https://familie-prosessering.intern.dev.nav.no"
   azure:
@@ -41,7 +40,6 @@ spec:
         - application: familie-baks-mottak
   resources:
     limits:
-      cpu: 2000m
       memory: 1024Mi
     requests:
       memory: 512Mi

--- a/build_n_deploy/naiserator/gcp-prod.yaml
+++ b/build_n_deploy/naiserator/gcp-prod.yaml
@@ -18,8 +18,7 @@ spec:
   replicas:
     min: 1
     max: 1
-    cpuThresholdPercentage: 50
-  ingresses: 
+  ingresses:
     - "https://familie-prosessering.intern.nav.no"
   azure:
     application:
@@ -42,7 +41,6 @@ spec:
         - application: familie-baks-mottak
   resources:
     limits:
-      cpu: 2000m
       memory: 1024Mi
     requests:
       memory: 512Mi


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)