### PR TITLE
Vise en enkelt task og tasker med samme callId

### DIFF
--- a/src/frontend/api/task.ts
+++ b/src/frontend/api/task.ts
@@ -33,6 +33,16 @@ export const hentTasks = (
     });
 };
 
+export const hentTasksMedCallId = (
+    valgtService: IService,
+    callId: string
+): Promise<Ressurs<ITaskResponse>> => {
+    return axiosRequest({
+        method: 'GET',
+        url: `${valgtService.proxyPath}/task/callId/${callId}`,
+    });
+};
+
 export const hentTask = (valgtService: IService, taskId: number): Promise<Ressurs<ITask>> => {
     return axiosRequest({
         method: 'GET',

--- a/src/frontend/api/task.ts
+++ b/src/frontend/api/task.ts
@@ -33,6 +33,13 @@ export const hentTasks = (
     });
 };
 
+export const hentTask = (valgtService: IService, taskId: number): Promise<Ressurs<ITask>> => {
+    return axiosRequest({
+        method: 'GET',
+        url: `${valgtService.proxyPath}/task/${taskId}`,
+    });
+};
+
 export const hentTasksSomErFerdigNåMenFeiletFør = (
     valgtService: IService
 ): Promise<Ressurs<ITaskResponse>> => {

--- a/src/frontend/komponenter/App.tsx
+++ b/src/frontend/komponenter/App.tsx
@@ -8,6 +8,7 @@ import Dekoratør from './Felleskomponenter/Dekoratør/Dekoratør';
 import GruppertTasks from './GruppertTasks/GruppertTasks';
 import { ServiceProvider } from './ServiceContext';
 import Services from './Services/Services';
+import TaskMedCallId from './Task/TaskMedCallId';
 import TaskMedId from './Task/TaskMedId';
 import Tasks from './Task/Tasks';
 import { TaskProvider } from './TaskProvider';
@@ -59,6 +60,14 @@ const App: React.FunctionComponent = () => {
                             element={
                                 <TaskProvider>
                                     <TaskMedId />
+                                </TaskProvider>
+                            }
+                        />
+                        <Route
+                            path="service/:service/tasker-med-call-id/:callId"
+                            element={
+                                <TaskProvider>
+                                    <TaskMedCallId />
                                 </TaskProvider>
                             }
                         />

--- a/src/frontend/komponenter/App.tsx
+++ b/src/frontend/komponenter/App.tsx
@@ -8,7 +8,7 @@ import Dekoratør from './Felleskomponenter/Dekoratør/Dekoratør';
 import GruppertTasks from './GruppertTasks/GruppertTasks';
 import { ServiceProvider } from './ServiceContext';
 import Services from './Services/Services';
-import TaskMedCallId from './Task/TaskMedCallId';
+import TasksMedCallId from './Task/TasksMedCallId';
 import TaskMedId from './Task/TaskMedId';
 import Tasks from './Task/Tasks';
 import { TaskProvider } from './TaskProvider';
@@ -67,7 +67,7 @@ const App: React.FunctionComponent = () => {
                             path="service/:service/tasker-med-call-id/:callId"
                             element={
                                 <TaskProvider>
-                                    <TaskMedCallId />
+                                    <TasksMedCallId />
                                 </TaskProvider>
                             }
                         />

--- a/src/frontend/komponenter/App.tsx
+++ b/src/frontend/komponenter/App.tsx
@@ -8,6 +8,7 @@ import Dekoratør from './Felleskomponenter/Dekoratør/Dekoratør';
 import GruppertTasks from './GruppertTasks/GruppertTasks';
 import { ServiceProvider } from './ServiceContext';
 import Services from './Services/Services';
+import TaskMedId from './Task/TaskMedId';
 import Tasks from './Task/Tasks';
 import { TaskProvider } from './TaskProvider';
 
@@ -50,6 +51,14 @@ const App: React.FunctionComponent = () => {
                             element={
                                 <TaskProvider>
                                     <GruppertTasks />
+                                </TaskProvider>
+                            }
+                        />
+                        <Route
+                            path="service/:service/task/:taskId"
+                            element={
+                                <TaskProvider>
+                                    <TaskMedId />
                                 </TaskProvider>
                             }
                         />

--- a/src/frontend/komponenter/Felleskomponenter/TopBar/TopBar.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/TopBar/TopBar.tsx
@@ -1,5 +1,6 @@
-import { Button, Checkbox, Heading, Select } from '@navikt/ds-react';
+import { Button, Checkbox, Heading, Search, Select } from '@navikt/ds-react';
 import React, { FC, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { taskStatus, taskStatusTekster } from '../../../typer/task';
 import { useServiceContext } from '../../ServiceContext';
 import { useTaskContext } from '../../TaskProvider';
@@ -14,6 +15,7 @@ const TopBar: FC = () => {
     } = useTaskContext();
     const { valgtService } = useServiceContext();
     const [visFeilaMenFerdig, setVisFeilaMenFerdig] = useState(false);
+    const navigate = useNavigate();
 
     return (
         <div className={'topbar'}>
@@ -44,19 +46,29 @@ const TopBar: FC = () => {
                     Vis de som feila, men nå er ferdige
                 </Checkbox>
             )}
-            <Select
-                onChange={(event) => settStatusFilter(event.target.value as taskStatus)}
-                value={statusFilter}
-                label={'Vis saker med status'}
-            >
-                {Object.values(taskStatus).map((status: taskStatus) => {
-                    return (
-                        <option key={status} value={status}>
-                            {taskStatusTekster[status]}
-                        </option>
-                    );
-                })}
-            </Select>
+            <div className={'søk'}>
+                <Select
+                    onChange={(event) => settStatusFilter(event.target.value as taskStatus)}
+                    value={statusFilter}
+                    label={'Status'}
+                >
+                    {Object.values(taskStatus).map((status: taskStatus) => {
+                        return (
+                            <option key={status} value={status}>
+                                {taskStatusTekster[status]}
+                            </option>
+                        );
+                    })}
+                </Select>
+                <Search
+                    label="Søk på callId"
+                    variant="secondary"
+                    hideLabel={false}
+                    onSearchClick={(verdi) => {
+                        navigate(`/service/${valgtService?.id}/tasker-med-call-id/${verdi}`);
+                    }}
+                />
+            </div>
         </div>
     );
 };

--- a/src/frontend/komponenter/Felleskomponenter/TopBar/top-bar.less
+++ b/src/frontend/komponenter/Felleskomponenter/TopBar/top-bar.less
@@ -3,4 +3,8 @@
     justify-content: space-between;
     align-items: center;
     padding: 1rem 1rem 0 1rem;
+    .søk {
+        display: flex;
+        gap: 1em;
+    }
 }

--- a/src/frontend/komponenter/Task/TaskMedCallId.tsx
+++ b/src/frontend/komponenter/Task/TaskMedCallId.tsx
@@ -5,28 +5,29 @@ import { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useServiceContext } from '../ServiceContext';
 import { useTaskContext } from '../TaskProvider';
+import TaskListe from './TaskListe';
 import TaskPanel from './TaskPanel';
 
 const TaskMedId: React.FC = () => {
-    const { settTaskId, task } = useTaskContext();
+    const { settCallId, tasks } = useTaskContext();
     const { valgtService } = useServiceContext();
-    const { taskId } = useParams();
+    const { callId } = useParams();
     useEffect(() => {
-        settTaskId(taskId ? parseInt(taskId, 10) : undefined);
+        settCallId(callId);
         // Fjern taskId når man går ut av dette skjermbildet
         return () => {
-            settTaskId(undefined);
+            settCallId(undefined);
         };
     }, []);
 
-    switch (task.status) {
+    switch (tasks.status) {
         case RessursStatus.SUKSESS:
             return (
                 <div style={{ margin: '0 2em' }}>
                     <Heading size={'large'}>
-                        {valgtService ? valgtService.displayName : ''} - TaskId: {task.data.id}
+                        {valgtService ? valgtService.displayName : ''} - CallId: {callId}
                     </Heading>
-                    <TaskPanel task={task.data} />
+                    <TaskListe tasks={tasks.data.tasks} />
                 </div>
             );
         case RessursStatus.HENTER:
@@ -34,13 +35,13 @@ const TaskMedId: React.FC = () => {
         case RessursStatus.IKKE_TILGANG:
             return (
                 <Alert variant={'warning'}>
-                    Ikke tilgang til tasker: {task.frontendFeilmelding}
+                    Ikke tilgang til tasker: {tasks.frontendFeilmelding}
                 </Alert>
             );
         case RessursStatus.FEILET:
             return (
                 <Alert variant={'error'}>
-                    Innhenting av tasker feilet: {task.frontendFeilmelding}
+                    Innhenting av tasker feilet: {tasks.frontendFeilmelding}
                 </Alert>
             );
         default:

--- a/src/frontend/komponenter/Task/TaskMedId.tsx
+++ b/src/frontend/komponenter/Task/TaskMedId.tsx
@@ -1,0 +1,46 @@
+import { Alert, Heading } from '@navikt/ds-react';
+import { RessursStatus } from '@navikt/familie-typer';
+import * as React from 'react';
+import { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useTaskContext } from '../TaskProvider';
+import TaskPanel from './TaskPanel';
+
+const TaskMedId: React.FC = () => {
+    const { settTaskId, task } = useTaskContext();
+    const { taskId } = useParams();
+    useEffect(() => {
+        settTaskId(taskId ? parseInt(taskId, 10) : undefined);
+        // Fjern taskId når man går ut av dette skjermbildet
+        return () => {
+            settTaskId(undefined);
+        };
+    }, []);
+
+    switch (task.status) {
+        case RessursStatus.SUKSESS:
+            return (
+                <div style={{ margin: '0 2em' }}>
+                    <Heading size={'large'}>TaskId: {task.data.id}</Heading>
+                    <TaskPanel task={task.data} />
+                </div>
+            );
+        case RessursStatus.HENTER:
+            return <Alert variant={'info'}>Laster tasker</Alert>;
+        case RessursStatus.IKKE_TILGANG:
+            return (
+                <Alert variant={'warning'}>
+                    Ikke tilgang til tasker: {task.frontendFeilmelding}
+                </Alert>
+            );
+        case RessursStatus.FEILET:
+            return (
+                <Alert variant={'error'}>
+                    Innhenting av tasker feilet: {task.frontendFeilmelding}
+                </Alert>
+            );
+        default:
+            return <div />;
+    }
+};
+export default TaskMedId;

--- a/src/frontend/komponenter/Task/TaskPanel.tsx
+++ b/src/frontend/komponenter/Task/TaskPanel.tsx
@@ -2,7 +2,9 @@ import { BodyShort, Button, Heading, Label, Link, Panel } from '@navikt/ds-react
 import classNames from 'classnames';
 import * as moment from 'moment';
 import React, { FC, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { ITask, taskStatusTekster, taskTypeTekster } from '../../typer/task';
+import { useServiceContext } from '../ServiceContext';
 import { useTaskContext } from '../TaskProvider';
 import AvvikshåndteringModal from './AvvikshåndteringModal/AvvikshåndteringModal';
 import KommenteringModal from './KommenteringModal/kommenteringModal';
@@ -19,6 +21,7 @@ const getSistKjørt = (task: ITask) =>
 
 const TaskPanel: FC<IProps> = ({ task }) => {
     const { rekjørTasks } = useTaskContext();
+    const { valgtService } = useServiceContext();
     const [visAvvikshåndteringModal, settVisAvvikshåndteringModal] = useState(false);
     const [visKommenteringModal, settVisKommenteringModal] = useState(false);
     const [visLogg, settVisLogg] = useState(false);
@@ -27,6 +30,7 @@ const TaskPanel: FC<IProps> = ({ task }) => {
     const kibanaInfoLenke = `https://logs.adeo.no/app/kibana#/discover/48543ce0-877e-11e9-b511-6967c3e45603?_g=(refreshInterval:(pause:!t,value:0),time:(from:'${task.opprettetTidspunkt}',mode:relative,to:now))&_a=(columns:!(message,envclass,environment,level,application,host),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-apps-*',key:team,negate:!f,params:(query:teamfamilie,type:phrase),type:phrase,value:teamfamilie),query:(match:(team:(query:teamfamilie,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:level,negate:!f,params:(query:Info,type:phrase),type:phrase,value:Info),query:(match:(level:(query:Info,type:phrase))))),index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:lucene,query:"${task.metadata.callId}"),sort:!('@timestamp',desc))`;
 
     const sistKjørt = getSistKjørt(task);
+    const navigate = useNavigate();
 
     return (
         <Panel className={'taskpanel'} border={true}>
@@ -99,17 +103,24 @@ const TaskPanel: FC<IProps> = ({ task }) => {
                     children={moment(task.opprettetTidspunkt).format('DD.MM.YYYY HH:mm')}
                 />
             </div>
-
-            <Button
-                className={'taskpanel__vislogg'}
-                variant={'secondary'}
-                onClick={(event) => {
-                    settVisLogg(!visLogg);
-                    event.preventDefault();
-                }}
-            >
-                {`${visLogg ? 'Skjul' : 'Vis'} logg (${task.antallLogger})`}
-            </Button>
+            <div className={'taskpanel__vislogg taskpanel__gruppert'}>
+                <Button
+                    className={'taskpanel__tilTask'}
+                    variant={'secondary'}
+                    onClick={() => navigate(`/service/${valgtService?.id}/task/${task.id}`)}
+                >
+                    Se task
+                </Button>
+                <Button
+                    variant={'secondary'}
+                    onClick={(event) => {
+                        settVisLogg(!visLogg);
+                        event.preventDefault();
+                    }}
+                >
+                    {`${visLogg ? 'Skjul' : 'Vis'} logg (${task.antallLogger})`}
+                </Button>
+            </div>
 
             <div className={classNames('taskpanel__logg', visLogg ? '' : 'skjul')}>
                 <TaskLogg taskId={task.id} visLogg={visLogg} />

--- a/src/frontend/komponenter/Task/TasksMedCallId.tsx
+++ b/src/frontend/komponenter/Task/TasksMedCallId.tsx
@@ -8,7 +8,7 @@ import { useTaskContext } from '../TaskProvider';
 import TaskListe from './TaskListe';
 import TaskPanel from './TaskPanel';
 
-const TaskMedId: React.FC = () => {
+const TasksMedCallId: React.FC = () => {
     const { settCallId, tasks } = useTaskContext();
     const { valgtService } = useServiceContext();
     const { callId } = useParams();
@@ -48,4 +48,4 @@ const TaskMedId: React.FC = () => {
             return <div />;
     }
 };
-export default TaskMedId;
+export default TasksMedCallId;

--- a/src/frontend/komponenter/Task/tasks.less
+++ b/src/frontend/komponenter/Task/tasks.less
@@ -60,6 +60,11 @@
         grid-area: 2 e("/") 4;
     }
 
+    &__gruppert {
+        display: flex;
+        flex-flow: column;
+    }
+
     &__logg {
         border-top: 1px solid @a-gray-600;
         grid-area: 3 e("/") 5 e("/") 3 e("/") 1;

--- a/src/frontend/komponenter/TaskProvider.tsx
+++ b/src/frontend/komponenter/TaskProvider.tsx
@@ -7,6 +7,7 @@ import {
     avvikshåndterTask,
     hentTask,
     hentTasks,
+    hentTasksMedCallId,
     hentTasksSomErFerdigNåMenFeiletFør,
     kommenterTask,
     rekjørTask,
@@ -52,14 +53,16 @@ const [TaskProvider, useTaskContext] = constate(() => {
     const [side, settSide] = useState<number>(getQueryParamSide(location));
     const [type, settTypeFilter] = useState<string>(getQueryParamTaskType(location));
     const [taskId, settTaskId] = useState<number | undefined>(getParamTaskId());
+    const [callId, settCallId] = useState<string | undefined>();
     const [task, settTask] = useState<Ressurs<ITask>>(byggTomRessurs());
 
     const hentEllerOppdaterTasks = () => {
-        console.log('Valgt service', valgtService);
-        console.log('Valgt taskId', taskId);
+        console.log(taskId, callId);
         if (valgtService) {
             if (taskId) {
                 hentTask(valgtService, taskId).then(settTask);
+            } else if (callId) {
+                hentTasksMedCallId(valgtService, callId).then(settTasks);
             } else {
                 hentTasks(valgtService, statusFilter, side, type).then(settTasks);
             }
@@ -68,11 +71,7 @@ const [TaskProvider, useTaskContext] = constate(() => {
 
     useEffect(() => {
         hentEllerOppdaterTasks();
-    }, [taskId]);
-
-    useEffect(() => {
-        hentEllerOppdaterTasks();
-    }, [valgtService, statusFilter, side, type]);
+    }, [valgtService, statusFilter, side, type, taskId, callId]);
 
     useEffect(() => {
         if (
@@ -141,6 +140,7 @@ const [TaskProvider, useTaskContext] = constate(() => {
         side,
         settSide,
         settTaskId,
+        settCallId,
         task,
         statusFilter,
         settStatusFilter,


### PR DESCRIPTION
Skal kunne se en enkelt task i prosessering:
- Dersom man ønsker å rekjøre en gammel task så er det vanskelig å "følge" status ettersom den forsvinner i dag. 
- Hvis man står i "en-enkelt-task"-skjermbildet og rekjører så kan man refreshe og følge tasken på en enkel måte

Søke opp alle tasks med samme callId
- Ofte er det callId i loggene som er nyttig for å slå opp tasker som har gått feil, og jeg har savnet muligheten til å følge alle tasker med samme callId på en enkel måte. I dagens "gruppert"-visning har man denne funksjonen HVIS de er innenfor samme `page` i utplukket, men i feilsituasjoner ønsker jeg å se dette tilbake i tid og følgelig kunne slå opp direkte.
<img width="1607" alt="Skjermbilde 2023-10-04 kl  13 49 35" src="https://github.com/navikt/familie-prosessering/assets/402915/8c2096cd-fc18-4c71-bfbe-444f997eb09d">
<img width="1591" alt="Skjermbilde 2023-10-04 kl  13 49 14" src="https://github.com/navikt/familie-prosessering/assets/402915/1d79e341-8435-4550-afd8-3d69e64b4e1b">
<img width="1589" alt="Skjermbilde 2023-10-04 kl  13 49 03" src="https://github.com/navikt/familie-prosessering/assets/402915/437652db-20c4-4a70-a52c-6e1bd2054878">
